### PR TITLE
fixes #27 – remove entity context for a cancelled stream.

### DIFF
--- a/cloudstate/cloudstate.go
+++ b/cloudstate/cloudstate.go
@@ -33,7 +33,7 @@ import (
 )
 
 const (
-	SupportLibraryVersion = "0.1.0"
+	SupportLibraryVersion = "0.1.1"
 	SupportLibraryName    = "cloudstate-go-support"
 )
 

--- a/cloudstate/eventsourced.go
+++ b/cloudstate/eventsourced.go
@@ -147,6 +147,12 @@ func (esh *EventSourcedServer) registerEntity(ese *EventSourcedEntity) error {
 func (esh *EventSourcedServer) Handle(stream protocol.EventSourced_HandleServer) error {
 	var entityId string
 	var failed error
+
+	// "fix" for https://github.com/cloudstateio/go-support/issues/27
+	// v0.2.x will contain the proper handling for the case of a closed stream.
+	defer func() {
+		delete(esh.contexts, entityId)
+	}()
 	for {
 		if failed != nil {
 			return failed

--- a/tck/cmd/tck_shoppingcart/shoppingcart.go
+++ b/tck/cmd/tck_shoppingcart/shoppingcart.go
@@ -34,7 +34,7 @@ import (
 func main() {
 	server, err := cloudstate.New(cloudstate.Config{
 		ServiceName:    "shopping-cart",
-		ServiceVersion: "0.1.0",
+		ServiceVersion: "0.1.1",
 	})
 	if err != nil {
 		log.Fatalf("CloudState.New failed: %v", err)


### PR DESCRIPTION
Fixes #27 – "Entity throws error after 30 seconds of inactivity". 

Please find a detailed analysis and script to reproduce the issue on the [issue](https://github.com/cloudstateio/go-support/issues/27#issuecomment-643663849) itself.

- the fix is valid for v0.1.0 and we'll release v0.1.1. The next milestone release will handle the entity context differently and this fix will not apply for the work currently done on the crdt branch which is the basis for milestone v0.2.0.
- #27 lists a shell script where the fix can be validated.
- a TCK image for v0.1.1 is already pushed to [docker hub](https://hub.docker.com/layers/cloudstateio/cloudstate-go-tck/0.1.1/images/sha256-913cd5d41bddf87eb64d0046cf3c302cbbf292c0160b0d131d0b347f7ed60783?context=repo) for verification.