### PR TITLE
[doc] https://pkg.go.dev/badge/ has been added.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Cloudstate stateful service support in Go
-[![GoDev](https://img.shields.io/static/v1?label=godev&message=reference&color=00add8)](https://pkg.go.dev/mod/github.com/cloudstateio/go-support)
+[![PkgGoDev](https://pkg.go.dev/badge/github.com/cloudstateio/go-support/cloudstate)](https://pkg.go.dev/github.com/cloudstateio/go-support)
 [![Build Status](https://travis-ci.com/cloudstateio/go-support.svg)](https://travis-ci.com/cloudstateio/go-support)
 [![Go Report Card](https://goreportcard.com/badge/github.com/cloudstateio/go-support)](https://goreportcard.com/report/github.com/cloudstateio/go-support)
 [![codecov](https://codecov.io/gh/cloudstateio/go-support/branch/master/graph/badge.svg)](https://codecov.io/gh/cloudstateio/go-support)


### PR DESCRIPTION
Use the pkg.go.dev badge as it has been released by the go.dev project now.
[![PkgGoDev](https://pkg.go.dev/badge/github.com/cloudstateio/go-support/cloudstate)](https://pkg.go.dev/github.com/cloudstateio/go-support/cloudstate)